### PR TITLE
Add first government intervention (taking back money)

### DIFF
--- a/src/wmd-console/UI/EndOfRoundPrinter.cs
+++ b/src/wmd-console/UI/EndOfRoundPrinter.cs
@@ -48,9 +48,24 @@ namespace WMD.Console.UI
                 case ReputationDecay reputationDecay:
                     System.Console.WriteLine($"{gameState.Players[reputationDecay.PlayerIndex].Identification.Name} lost {reputationDecay.ReputationPercentageLost}% reputation due to time.");
                     break;
+                case GovernmentIntervention intervention:
+                    PrintGovernmentIntervention(gameState, intervention);
+                    break;
                 default:
                     throw new ArgumentException($"Unrecognized {typeof(RoundUpdateResultItem).Name} subclass: {item.GetType().Name}.");
             }
+            System.Console.WriteLine();
+        }
+
+        private static void PrintGovernmentIntervention(GameState gameState, GovernmentIntervention intervention)
+        {
+            string interventionText = intervention switch
+            {
+                GovernmentTakesBackMoney occurrence => $"A government seized {occurrence.AmountTaken:C} from {gameState.Players[occurrence.PlayerIndex].Identification.Name}.",
+                _ => throw new ArgumentException($"Unrecognized {typeof(GovernmentIntervention).Name} subclass: {intervention.GetType().Name}."),
+            };
+
+            System.Console.WriteLine(interventionText);
             System.Console.WriteLine();
         }
     }

--- a/src/wmd-core/State/Updates/Rounds/GameStateRoundAdvancer.cs
+++ b/src/wmd-core/State/Updates/Rounds/GameStateRoundAdvancer.cs
@@ -17,6 +17,7 @@ namespace WMD.Game.State.Updates.Rounds
                 new PlayerHenchmenPaidOccurrencesCreator(),
                 new PlayerHenchmenQuitOccurrencesCreator(),
                 new ReputationDecayOccurrencesCreator(),
+                new GovernmentInterventionOccurrencesCreator(),
             };
         }
 

--- a/src/wmd-core/State/Updates/Rounds/GameStateRoundAdvancer.cs
+++ b/src/wmd-core/State/Updates/Rounds/GameStateRoundAdvancer.cs
@@ -29,6 +29,12 @@ namespace WMD.Game.State.Updates.Rounds
             return (updatedGameState, result);
         }
 
+        private static GameState ApplyGovernmentIntervention(GameState gameState, GovernmentIntervention intervention) => intervention switch
+        {
+            GovernmentTakesBackMoney occurrence => GameStateUpdater.AdjustMoneyForPlayer(gameState, occurrence.PlayerIndex, -1 * occurrence.AmountTaken),
+            _ => throw new ArgumentException($"Unrecognized {typeof(GovernmentIntervention).Name} subclass: {intervention.GetType().Name}."),
+        };
+
         private static GameState ApplyRoundUpdates(GameState gameState, RoundUpdateResult roundUpdates)
         {
             var updatedGameState = gameState;
@@ -53,6 +59,7 @@ namespace WMD.Game.State.Updates.Rounds
             PlayerHenchmenPaid playerHenchmenPaid => GameStateUpdater.AdjustMoneyForPlayer(gameState, playerHenchmenPaid.PlayerIndex, -1 * playerHenchmenPaid.TotalPaidAmount),
             PlayerHenchmenQuit playerHenchmenQuit => GameStateUpdater.AdjustHenchmenForPlayer(gameState, playerHenchmenQuit.PlayerIndex, -1 * playerHenchmenQuit.NumberOfHenchmenQuit),
             ReputationDecay reputationDecay => GameStateUpdater.AdjustReputationForPlayer(gameState, reputationDecay.PlayerIndex, -1 * reputationDecay.ReputationPercentageLost),
+            GovernmentIntervention governmentIntervention => ApplyGovernmentIntervention(gameState, governmentIntervention),
             _ => throw new ArgumentException($"Unrecognized {typeof(RoundUpdateResultItem).Name} subclass: {roundUpdate.GetType().Name}."),
         };
 

--- a/src/wmd-core/State/Updates/Rounds/GovernmentIntervention.cs
+++ b/src/wmd-core/State/Updates/Rounds/GovernmentIntervention.cs
@@ -1,0 +1,10 @@
+﻿namespace WMD.Game.State.Updates.Rounds
+{
+    /// <summary>
+    /// An occurrence of a government intervention.
+    /// This class cannot be instantiated.
+    /// </summary>
+    public abstract record GovernmentIntervention : RoundUpdateResultItem
+    {
+    }
+}

--- a/src/wmd-core/State/Updates/Rounds/GovernmentInterventionOccurrencesCreator.cs
+++ b/src/wmd-core/State/Updates/Rounds/GovernmentInterventionOccurrencesCreator.cs
@@ -24,7 +24,7 @@ namespace WMD.Game.State.Updates.Rounds
 
             var interventions = new Queue<GovernmentIntervention>();
 
-            if (_random.NextDouble() > BaseChanceOfGovernmentIntervention && gameState.Players[playerIndex].State.Money > 0)
+            if (GovernmentDecidesToTakeIntervention(gameState, playerIndex) && gameState.Players[playerIndex].State.Money > 0)
             {
                 interventions.Enqueue(CreateTakesBackMoneyOccurrence(gameState, playerIndex));
             }
@@ -34,6 +34,16 @@ namespace WMD.Game.State.Updates.Rounds
 
         private static GovernmentTakesBackMoney CreateTakesBackMoneyOccurrence(GameState gameState, int playerIndex) =>
             new(gameState, playerIndex, Math.Min(gameState.Players[playerIndex].State.Money, BaseAmountOfMoneyTakenBack));
+
+        private static bool GovernmentDecidesToTakeIntervention(GameState gameState, int playerIndex)
+        {
+            double additionalChanceOfIntervention = Math.Max(
+                (gameState.Players[playerIndex].State.ReputationPercentage - MinimumNoticeableReputationPercentage) / 100.0,
+                1 - BaseChanceOfGovernmentIntervention
+            );
+
+            return _random.NextDouble() < BaseChanceOfGovernmentIntervention + additionalChanceOfIntervention;
+        }
 
         private static readonly Random _random;
     }

--- a/src/wmd-core/State/Updates/Rounds/GovernmentTakesBackMoney.cs
+++ b/src/wmd-core/State/Updates/Rounds/GovernmentTakesBackMoney.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using WMD.Game.State.Data;
+
+namespace WMD.Game.State.Updates.Rounds
+{
+    /// <summary>
+    /// An occurrence of a government taking back money from a player.
+    /// </summary>
+    public record GovernmentTakesBackMoney : GovernmentIntervention
+    {
+        private const string ArgumentOutOfRangeException_AmountTakenExceedsPlayerAmount = "The amount of money taken cannot exceed the amount the player actually has.";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GovernmentTakesBackMoney"/> class.
+        /// </summary>
+        /// <param name="gameState">The <see cref="GameState"/>.</param>
+        /// <param name="playerIndex">The index of the player who had their money taken.</param>
+        /// <param name="amountTaken">The amount of money that was taken.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="amountTaken"/> is greater than the amount of money the player actually has.
+        /// </exception>
+        public GovernmentTakesBackMoney(GameState gameState, int playerIndex, decimal amountTaken)
+        {
+            var playerState = gameState.Players[playerIndex].State;
+            if (amountTaken > playerState.Money)
+            {
+                throw new ArgumentOutOfRangeException(nameof(amountTaken), amountTaken, ArgumentOutOfRangeException_AmountTakenExceedsPlayerAmount);
+            }
+            PlayerIndex = playerIndex;
+            AmountTaken = amountTaken;
+        }
+
+        /// <summary>
+        /// Gets the amount of money that was taken.
+        /// </summary>
+        public decimal AmountTaken { get; init; }
+
+        /// <summary>
+        /// Gets the index of the player whose money was taken.
+        /// </summary>
+        public int PlayerIndex { get; init; }
+    }
+}


### PR DESCRIPTION
Fixes #28 by letting governments take back stolen money from players in between rounds based on their reputation percentage.