### PR TITLE
Update MSTest dependencies

### DIFF
--- a/test/wmd-core-test/wmd-core-test.csproj
+++ b/test/wmd-core-test/wmd-core-test.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 

--- a/test/wmd-core-test/wmd-core-test.csproj
+++ b/test/wmd-core-test/wmd-core-test.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>


### PR DESCRIPTION
This replaces Dependabot pull requests #103 and #104 since MSTest.TestFramework and MSTest.TestAdapter need to be updated together to work properly.